### PR TITLE
try and catch errors during webhook delivery

### DIFF
--- a/class.pmprogateway_paystack.php
+++ b/class.pmprogateway_paystack.php
@@ -308,6 +308,7 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                                 $pstk_logger = new pmpro_paystack_plugin_tracker('pm-pro', $pk);
                                 $pstk_logger->log_transaction_success($event->data->reference);
                                 if ($txnstatus['member'] === 'success') {
+                                    echo 'transaction successful';
                                     http_response_code(200);
                                     exit();
                                 }
@@ -316,7 +317,12 @@ if (!function_exists('Paystack_Pmp_Gateway_load')) {
                                 self::renewpayment($event);
                             case 'invoice.update':
                                 self::renewpayment($event);
+                            default:
+                                echo 'Event not recognized';
+                                http_response_code(400);
+                                exit();    
                         }
+                        echo 'kill switch';
                         http_response_code(200);
                         exit();
                     }


### PR DESCRIPTION
1. Wrapped the `pmpro_paystack_ipn()` function in a try and catch
2. Added the appropriate http response code and error message for the signature validation.
3. Implemented a check to verify if the transaction is successful before returning a 200 response code.